### PR TITLE
Resolves 2.3.0 incompatibility and reduces deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,29 +1,24 @@
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.16'
+gem 'rails', '~>3.2.22.2'
 gem 'rails_12factor'
-
-
-# Bundle edge Rails instead:
-# gem 'rails', :git => 'git://github.com/rails/rails.git'
-
 gem 'haml-rails'
-
 gem 'selenium-webdriver'
 gem 'poltergeist'
-
-gem 'authlogic'#, :git => "git://github.com/binarylogic/authlogic.git"
-
+gem 'authlogic'
 gem 'twilio-ruby'
-
+gem 'jquery-rails'
 gem 'rubocop'
 gem 'simplecov'
 
-# Normalize.css is a customisable CSS file that makes browsers render all elements more consistently and in line with modern standards.
+# Normalize.css is a customisable CSS file that makes browsers render all
+#   elements more consistently and in line with modern standards.
 gem 'normalize-rails'
 
-# In order to avoid the json 1.8.1 bug (https://travis-ci.org/CSC322-Grinnell/notifications/jobs/110022386), force an unbroken version
-  gem 'json', '~>1.8.2'
+# In order to avoid the json 1.8.1 bug
+#   (https://travis-ci.org/CSC322-Grinnell/notifications/jobs/110022386), force
+#   an unbroken version
+gem 'json', '~>1.8.2'
 
 group :development, :test do
   gem 'sqlite3'
@@ -48,32 +43,10 @@ group :production do
   gem 'heroku'
 end
 
-
 # Gems used only for assets and not required
-# in production environments by default.
+#   in production environments by default.
 group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'
-
-  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  # gem 'therubyracer', :platforms => :ruby
-
   gem 'uglifier', '>= 1.0.3'
 end
-
-gem 'jquery-rails'
-
-# To use ActiveModel has_secure_password
-# gem 'bcrypt-ruby', '~> 3.0.0'
-
-# To use Jbuilder templates for JSON
-# gem 'jbuilder'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Deploy with Capistrano
-# gem 'capistrano'
-
-# To use debugger
-# gem 'debugger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (3.2.16)
-      actionpack (= 3.2.16)
+    actionmailer (3.2.22.2)
+      actionpack (= 3.2.22.2)
       mail (~> 2.5.4)
-    actionpack (3.2.16)
-      activemodel (= 3.2.16)
-      activesupport (= 3.2.16)
+    actionpack (3.2.22.2)
+      activemodel (= 3.2.22.2)
+      activesupport (= 3.2.22.2)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
       journey (~> 1.0.4)
@@ -14,18 +14,18 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    activemodel (3.2.16)
-      activesupport (= 3.2.16)
+    activemodel (3.2.22.2)
+      activesupport (= 3.2.22.2)
       builder (~> 3.0.0)
-    activerecord (3.2.16)
-      activemodel (= 3.2.16)
-      activesupport (= 3.2.16)
+    activerecord (3.2.22.2)
+      activemodel (= 3.2.22.2)
+      activesupport (= 3.2.22.2)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activeresource (3.2.16)
-      activemodel (= 3.2.16)
-      activesupport (= 3.2.16)
-    activesupport (3.2.16)
+    activeresource (3.2.22.2)
+      activemodel (= 3.2.22.2)
+      activesupport (= 3.2.22.2)
+    activesupport (3.2.22.2)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.4.0)
@@ -48,7 +48,9 @@ GEM
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
-    coderay (1.1.0)
+    codeclimate-test-reporter (0.5.0)
+      simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.1)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -79,7 +81,7 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
-    excon (0.45.4)
+    excon (0.47.0)
     execjs (2.6.0)
     ffi (1.9.10)
     ffi-compiler (0.1.3)
@@ -93,7 +95,7 @@ GEM
       activesupport (>= 3.1, < 4.1)
       haml (>= 3.1, < 4.1)
       railties (>= 3.1, < 4.1)
-    heroku (3.42.36)
+    heroku (3.42.38)
       heroku-api (= 0.3.23)
       launchy (= 2.4.3)
       multi_json (= 1.11.2)
@@ -112,7 +114,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    jwt (1.5.2)
+    jwt (1.5.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     mail (2.5.4)
@@ -155,22 +157,22 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (3.2.16)
-      actionmailer (= 3.2.16)
-      actionpack (= 3.2.16)
-      activerecord (= 3.2.16)
-      activeresource (= 3.2.16)
-      activesupport (= 3.2.16)
+    rails (3.2.22.2)
+      actionmailer (= 3.2.22.2)
+      actionpack (= 3.2.22.2)
+      activerecord (= 3.2.22.2)
+      activeresource (= 3.2.22.2)
+      activesupport (= 3.2.22.2)
       bundler (~> 1.0)
-      railties (= 3.2.16)
+      railties (= 3.2.22.2)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.4)
-    railties (3.2.16)
-      actionpack (= 3.2.16)
-      activesupport (= 3.2.16)
+    railties (3.2.22.2)
+      actionpack (= 3.2.22.2)
+      activesupport (= 3.2.22.2)
       rack-ssl (~> 1.3.2)
       rake (>= 0.8.7)
       rdoc (~> 3.4)
@@ -183,7 +185,7 @@ GEM
     rest-client (1.6.8)
       mime-types (~> 1.16)
       rdoc (>= 2.4.2)
-    rspec-core (3.4.2)
+    rspec-core (3.4.3)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -213,7 +215,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    scrypt (2.0.2)
+    scrypt (2.1.1)
       ffi-compiler (>= 0.0.2)
       rake
     selenium-webdriver (2.52.0)
@@ -262,6 +264,7 @@ PLATFORMS
 DEPENDENCIES
   authlogic
   capybara
+  codeclimate-test-reporter
   coffee-rails (~> 3.2.1)
   cucumber-rails
   cucumber-rails-training-wheels
@@ -275,7 +278,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry-byebug
-  rails (= 3.2.16)
+  rails (~> 3.2.22.2)
   rails_12factor
   rspec-rails
   rubocop
@@ -286,3 +289,6 @@ DEPENDENCIES
   test-unit
   twilio-ruby
   uglifier (>= 1.0.3)
+
+BUNDLED WITH
+   1.11.2

--- a/features/classroom_not_admin.feature
+++ b/features/classroom_not_admin.feature
@@ -1,4 +1,4 @@
-Feature: Group stuents into classrooms as a techer
+Feature: Group students into classrooms as a teacher
 
   As a teacher
   I would like to be able to view and text classrooms with students

--- a/features/step_definitions/classroom_steps.rb
+++ b/features/step_definitions/classroom_steps.rb
@@ -1,5 +1,5 @@
 Given /the following classrooms exist/ do |classroom_table|
   classroom_table.hashes.each do |classroom|
-   Classroom.create! classroom
-end
+    Classroom.create! classroom
+  end
 end

--- a/features/step_definitions/student_steps.rb
+++ b/features/step_definitions/student_steps.rb
@@ -2,5 +2,5 @@
 Given /the following students exist/ do |student_table|
   student_table.hashes.each do |student|
    Student.create! student
-end
+  end
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,9 +1,5 @@
 Given /the following users exist/ do |users_table|
   users_table.hashes.each do |user|
   	User.create!(user)
-    # each returned element will be a hash whose key is the table header.
-    # you should arrange to add that movie to the database here.
   end
-
-
 end


### PR DESCRIPTION
Closes #29.
Updating Rails was the biggest part of this, but stayed with 3.x version for the time being. We should think about updating this as soon as tests pass.
